### PR TITLE
BUG-FIX - Can't find metadata for "App/Entity/Dog"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.2.5",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "doctrine/annotations": "^1.0",
+        "doctrine/annotations": "^1.13",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea5268facfc4794eae0436f4714b8b2e",
+    "content-hash": "a70958f00b108a92f4aa4904b82091a2",
     "packages": [
         {
             "name": "doctrine/annotations",

--- a/migrations/Version20220311182202.php
+++ b/migrations/Version20220311182202.php
@@ -10,24 +10,24 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20220309215858 extends AbstractMigration
+final class Version20220311182202 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Create the dogs table (basically users)';
+        return '';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE SEQUENCE dog_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE SEQUENCE dogs_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
         $this->addSql('CREATE TABLE dogs (id INT NOT NULL, username VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
-        $this->addSql('CREATE UNIQUE INDEX UNIQ_812C397DF85E0677 ON dogs (username)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_812c397df85e0677 ON dogs (username)');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('CREATE SCHEMA public');
-        $this->addSql('DROP SEQUENCE dog_id_seq CASCADE');
+        $this->addSql('DROP SEQUENCE dogs_id_seq CASCADE');
         $this->addSql('DROP TABLE dogs');
     }
 }

--- a/src/Entity/Dog.php
+++ b/src/Entity/Dog.php
@@ -2,28 +2,47 @@
 
 namespace App\Entity;
 
-use App\Repository\DogRepository;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-#[ORM\Entity(repositoryClass: DogRepository::class)]
-#[UniqueEntity(fields: ['username'], message: 'There is already an account with this username')]
+/**
+ * Dog
+ *
+ * @ORM\Table(name="dogs", uniqueConstraints={@ORM\UniqueConstraint(name="uniq_812c397df85e0677", columns={"username"})})
+ * @ORM\Entity
+ */
 class Dog implements UserInterface, PasswordAuthenticatedUserInterface
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="SEQUENCE")
+     * @ORM\SequenceGenerator(sequenceName="dogs_id_seq", allocationSize=1, initialValue=1)
+     */
     private $id;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="username", type="string", length=180, nullable=false)
+     */
     private $username;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    /**
+     * @var array
+     *
+     * @ORM\Column(name="roles", type="json", nullable=false)
+     */
+    private $roles;
 
-    #[ORM\Column(type: 'string')]
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="password", type="string", length=255, nullable=false)
+     */
     private $password;
 
     public function getId(): ?int
@@ -109,4 +128,6 @@ class Dog implements UserInterface, PasswordAuthenticatedUserInterface
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;
     }
+
+
 }


### PR DESCRIPTION
## Bug description

Metadata in entities could not be read by the webserver. This was causing get requests to `/register` to fail with a pretty unhelpful trace.

## Expected

To be able to navigate the page and see the UI without errors

## Diagnosis

PHP8 supports metadata tags using `#` whereas 7 only supports doc blocks. Because 7 could not support the new style metadata tag, it was not reading the metadata for the component at all. 

https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/attributes-reference.html#attributes-reference 